### PR TITLE
fix folder move to_old

### DIFF
--- a/gen-links.sh
+++ b/gen-links.sh
@@ -7,7 +7,7 @@ function mkln () {
     to="$2"
 
     if ! [ -L "$to" ]; then # Move if it is not a link
-        mv "$to" "$to_OLD" > /dev/null 2> /dev/null && echo "Moved $to to $to_OLD"
+        mv "$to" "${to}_OLD" > /dev/null 2> /dev/null && echo "Moved $to to ${to}_OLD"
     else # Otherwise, yeet it
         target="$(readlink -f "$to")"
         rm "$to" &> /dev/null && echo "Removed previous link ${to/$HOME/~} -> ${target/$HOME/~}"


### PR DESCRIPTION
as i was using your gen_links.sh script, it occurred to me that on line 10 the variable "$to_old" is not set. 
My change makes this line work as intended (in my interpretation, maybe you had another thought with that).
I'm making my own personal config and have taken yours as my template.
Maybe i can inspire you in some way: https://github.com/lockenkop/personal-config
You have inspired me alot!